### PR TITLE
fix(readme): fix quickstart link in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 
 ## Quickstart
-- for quickstart ,see [tars_go_quickstart_en.md](docs/tars_go_quickstart_en.md)
-- 快速开始，请查看 [tars_go_quickstart.md](docs/tars_go_quickstart.md)
+- for quickstart ,see [tars_go_quickstart_en.md](tars/docs/tars_go_quickstart_en.md)
+- 快速开始，请查看 [tars_go_quickstart.md](tars/docs/tars_go_quickstart.md)
 
 
 ## Usage

--- a/tars/README.md
+++ b/tars/README.md
@@ -24,8 +24,8 @@
 
 
 ## Quickstart
-- for quickstart ,see [tars_go_quickstart_en.md](tars/docs/tars_go_quickstart_en.md)
-- 快速开始，请查看 [tars_go_quickstart.md](tars/docs/tars_go_quickstart.md)
+- for quickstart ,see [tars_go_quickstart_en.md](docs/tars_go_quickstart_en.md)
+- 快速开始，请查看 [tars_go_quickstart.md](docs/tars_go_quickstart.md)
 
 
 ## Usage


### PR DESCRIPTION
The quickstart link in readme file is broken.
I change the relevant directory to fix it.