### PR TITLE
- is this useful here?

### DIFF
--- a/tars/util/rogger/logger.go
+++ b/tars/util/rogger/logger.go
@@ -52,8 +52,8 @@ func init() {
 	currDateDay = now.Format("20060102")
 	go func() {
 		tm := time.NewTimer(time.Second)
-		if err := recover(); err != nil { // avoid timer panic
-		}
+		// if err := recover(); err != nil { // avoid timer panic
+		// }
 		for {
 			now := time.Now()
 			d := time.Second - time.Duration(now.Nanosecond())


### PR DESCRIPTION
don't think timer would produce a panic, even if it does, should be:

```golang
defer func() {
    if err := recover(); err != nil { // avoid timer panic
    }
}()
```