### PR TITLE
fix GetConfig fail on tars public cloud env

### DIFF
--- a/tars/rconfig.go
+++ b/tars/rconfig.go
@@ -28,7 +28,7 @@ type RConf struct {
 func NewRConf(app string, server string, path string) *RConf {
 	comm := NewCommunicator()
 	tc := new(configf.Config)
-	obj := "tars.tarsconfig.ConfigObj"
+	obj := GetServerConfig().config
 
 	comm.StringToProxy(obj, tc)
 	return &RConf{app, server, comm, tc, path}


### PR DESCRIPTION
在公有云（如tars.tencent.com）等环境，写死配置服务obj为tars.tarsconfig.ConfigObj会导致配置拉取失败，改为从模版中获取配置服务的obj