### PR TITLE
flag.Parse() must not be called during init. Instead, register flags during init, and call flag.Parse() in main().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+  - '1.9'
+  - 1.10.x
+script:
+  - go build tars

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: go
 go:
   - '1.9'
   - 1.10.x
+  - 1.11.x
 install:
   - echo "$GOPATH"
 script:
-  - go build tars
+  - go build github.com/TarsCloud/TarsGo/tars

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: go
 go:
   - '1.9'
   - 1.10.x
+install:
+  - echo "$GOPATH"
 script:
   - go build tars

--- a/tars/application.go
+++ b/tars/application.go
@@ -40,7 +40,13 @@ func init() {
 	shutdown = make(chan bool, 1)
 	adminMethods = make(map[string]adminFn)
 	rogger.SetLevel(rogger.ERROR)
-	Init()
+	registerFlag()
+}
+
+var confPath string
+
+func registerFlag() {
+	flag.StringVar(&confPath, "config", "", "init config path")
 }
 
 //Init should run before GetServerConfig & GetClientConfig , or before run
@@ -50,12 +56,10 @@ func Init() {
 }
 
 func initConfig() {
-	confPath := flag.String("config", "", "init config path")
-	flag.Parse()
-	if len(*confPath) == 0 {
+	if len(confPath) == 0 {
 		return
 	}
-	c, err := conf.NewConf(*confPath)
+	c, err := conf.NewConf(confPath)
 	if err != nil {
 		TLOG.Error("open app config fail")
 	}

--- a/tars/rconfig.go
+++ b/tars/rconfig.go
@@ -28,7 +28,7 @@ type RConf struct {
 func NewRConf(app string, server string, path string) *RConf {
 	comm := NewCommunicator()
 	tc := new(configf.Config)
-	obj := "tars.tarsconfig.ConfigObj"
+	obj := GetServerConfig().config
 
 	comm.StringToProxy(obj, tc)
 	return &RConf{app, server, comm, tc, path}

--- a/tars/remotelogger.go
+++ b/tars/remotelogger.go
@@ -13,6 +13,7 @@ type RemoteTimeWriter struct {
 	logPtr        *logf.Log
 	reportSuccPtr *PropertyReport
 	reportFailPtr *PropertyReport
+	hasPrefix     bool
 }
 
 //NewRemoteTimeWriter new and init RemoteTimeWriter
@@ -135,7 +136,11 @@ func (rw *RemoteTimeWriter) InitFormat(s string) {
 
 //NeedPrefix return if need prefix for the logger.
 func (rw *RemoteTimeWriter) NeedPrefix() bool {
-	return false
+	return rw.hasPrefix
+}
+
+func (rw *RemoteTimeWriter) SetPrefix(enable bool) {
+	rw.hasPrefix = enable
 }
 
 //Write Writes the logs to the buffer.

--- a/tars/servant.go
+++ b/tars/servant.go
@@ -71,7 +71,7 @@ func (s *ServantProxy) Tars_invoke(ctx context.Context, ctype byte,
 		err = s.obj.Invoke(ctx, msg, time.Duration(s.timeout)*time.Millisecond)
 	}
 	if err != nil {
-		TLOG.Error("Invoke error:", s.name, sFuncName, err.Error())
+		TLOG.Errorf("Invoke Obj:%s,fun:%s,error:%s", s.name, sFuncName, err.Error())
 		if msg.Resp == nil {
 			ReportStat(msg, 0, 0, 1)
 		} else if msg.Status == basef.TARSINVOKETIMEOUT {

--- a/tars/statf.go
+++ b/tars/statf.go
@@ -163,7 +163,7 @@ func ReportStatFromClient(msg *Message, succ int32, timeout int32, exec int32) {
 	head.InterfaceName = msg.Req.SFuncName
 	sNames := strings.Split(msg.Req.SServantName, ".")
 	if len(sNames) < 2 {
-		TLOG.Debug("report err:servant name (%s) format error", msg.Req.SServantName)
+		TLOG.Debugf("report err:servant name (%s) format error", msg.Req.SServantName)
 		return
 	}
 	head.SlaveName = fmt.Sprintf("%s.%s", sNames[0], sNames[1])

--- a/tars/tools/tars2go/gen_go.go
+++ b/tars/tools/tars2go/gen_go.go
@@ -712,7 +712,7 @@ func (gen *GenGo) genEnum(en *EnumInfo) {
 	c.WriteString("type " + en.TName + " int32\n")
 	c.WriteString("const (\n")
 	for _, v := range en.Mb {
-		c.WriteString("//" + gen.makeEnumName(en, &v) + " enum")
+		c.WriteString("//" + gen.makeEnumName(en, &v) + " enum\n")
 		c.WriteString(gen.makeEnumName(en, &v) + ` = ` + strconv.Itoa(int(v.Value)) + "\n")
 	}
 

--- a/tars/util/rogger/logger.go
+++ b/tars/util/rogger/logger.go
@@ -234,9 +234,10 @@ func (l *Logger) writef(level LogLevel, format string, v []interface{}) {
 			}
 			fmt.Fprintf(buf, "%s:%d|", file, line)
 		}
+		
+		buf.WriteString(level.String())
+		buf.WriteByte('|')
 	}
-	buf.WriteString(level.String())
-	buf.WriteByte('|')
 
 	if format == "" {
 		fmt.Fprint(buf, v...)

--- a/tars/util/rogger/logwriter.go
+++ b/tars/util/rogger/logwriter.go
@@ -37,13 +37,14 @@ type RollFileWriter struct {
 
 //DateWriter rotate logs by date.
 type DateWriter struct {
-	logpath  string
-	name     string
-	dateType DateType
-	num      int
-	currDate string
-	currFile *os.File
-	openTime int64
+	logpath   string
+	name      string
+	dateType  DateType
+	num       int
+	currDate  string
+	currFile  *os.File
+	openTime  int64
+	hasPrefix bool
 }
 
 //HourWriter for rotate logs by hour
@@ -147,16 +148,21 @@ func (w *DateWriter) Write(v []byte) {
 
 //NeedPrefix shows whether needs prefix info for DateWriter or not.
 func (w *DateWriter) NeedPrefix() bool {
-	return true
+	return w.hasPrefix
+}
+
+func (w *DateWriter) SetPrefix(enable bool) {
+	w.hasPrefix = enable
 }
 
 //NewDateWriter returns a writer which keeps logs in hours or day format.
 func NewDateWriter(logpath, name string, dateType DateType, num int) *DateWriter {
 	w := &DateWriter{
-		logpath:  logpath,
-		name:     name,
-		num:      num,
-		dateType: dateType,
+		logpath:   logpath,
+		name:      name,
+		num:       num,
+		dateType:  dateType,
+		hasPrefix: true,
 	}
 	w.currDate = w.getCurrDate()
 	return w


### PR DESCRIPTION
flag.Parse() must not be called during init. Instead, register flags during init, and call flag.Parse() in main().
Otherwise, if your own program or a 3rd-party lib(say, glog) you use registers flags during init and expects flags to be parsed during execution, your program will panic with "flag provided but not defined".