### PR TITLE
exit when config is nil.avoid user hold nil config

### DIFF
--- a/tars/application.go
+++ b/tars/application.go
@@ -61,11 +61,13 @@ func initConfig() {
 	confPath := flag.String("config", "", "init config path")
 	flag.Parse()
 	if len(*confPath) == 0 {
-		return
+		TLOG.Error("app config not found")
+		os.Exit(1)
 	}
 	c, err := conf.NewConf(*confPath)
 	if err != nil {
 		TLOG.Error("open app config fail")
+		os.Exit(1)
 	}
 	//Config.go
 	//Server


### PR DESCRIPTION
### issue

https://github.com/TarsCloud/TarsGo/pull/114

### describe

exit when config is nil ,avoid user hold the nil config and use it.Nil make things weird