### PR TITLE
[*] add configurable max package length

### DIFF
--- a/tars/application.go
+++ b/tars/application.go
@@ -83,6 +83,8 @@ func initConfig() {
 	svrCfg.DataPath = sMap["datapath"]
 	//svrCfg.netThread = sMap["netthread"]
 	svrCfg.netThread = c.GetInt("/tars/application/server<netthread>")
+	// max package length, default is 1M
+	svrCfg.MaxPackageLength = c.GetInt("/tars/application/server<maxPackageLength>")
 
 	svrCfg.log = sMap["log"]
 	//add version info

--- a/tars/appprotocol.go
+++ b/tars/appprotocol.go
@@ -15,11 +15,15 @@ const (
 
 //TarsRequest parse full tars request from package
 func TarsRequest(rev []byte) (int, int) {
+	maxLength := iMaxLength
+	if svrCfg.MaxPackageLength > 0 {
+		maxLength = svrCfg.MaxPackageLength
+	}
 	if len(rev) < 4 {
 		return 0, PACKAGE_LESS
 	}
 	iHeaderLen := int(binary.BigEndian.Uint32(rev[0:4]))
-	if iHeaderLen < 4 || iHeaderLen > iMaxLength {
+	if iHeaderLen < 4 || iHeaderLen > maxLength {
 		return 0, PACKAGE_ERROR
 	}
 	if len(rev) < iHeaderLen {

--- a/tars/config.go
+++ b/tars/config.go
@@ -44,10 +44,11 @@ type serverConfig struct {
 	netThread int
 	Adapters  map[string]adapterConfig
 
-	Container   string
-	Isdocker    bool
-	Enableset   bool
-	Setdivision string
+	Container        string
+	Isdocker         bool
+	Enableset        bool
+	Setdivision      string
+	MaxPackageLength int
 }
 
 type clientConfig struct {


### PR DESCRIPTION
增加可配置的包体大小限制（私有模版/tars/application/server<maxPackageLength>）。现有tarsgo默认最大包大小为1M，和其他语言tars框架限制不同（如tarsc++的10M），这里做成配置项并保留默认1M的限制，防止个别需求场景出现parse package error错误