### PR TITLE
add configurable package length

### DIFF
--- a/tars/application.go
+++ b/tars/application.go
@@ -128,6 +128,7 @@ func initConfig() {
 	svrCfg.StatReportInterval = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<statreportinterval>", StatReportInterval))
 	svrCfg.MainLoopTicker = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<mainloopticker>", MainLoopTicker))
 
+	svrCfg.MaxPackageLength = c.GetIntWithDef("/tars/application/server<maxPackageLength>", iMaxLength)
 	//client
 	cltCfg = new(clientConfig)
 	cMap := c.GetMap("/tars/application/client")

--- a/tars/appprotocol.go
+++ b/tars/appprotocol.go
@@ -19,7 +19,7 @@ func TarsRequest(rev []byte) (int, int) {
 		return 0, PACKAGE_LESS
 	}
 	iHeaderLen := int(binary.BigEndian.Uint32(rev[0:4]))
-	if iHeaderLen < 4 || iHeaderLen > iMaxLength {
+	if iHeaderLen < 4 || iHeaderLen > svrCfg.MaxPackageLength {
 		return 0, PACKAGE_ERROR
 	}
 	if len(rev) < iHeaderLen {

--- a/tars/config.go
+++ b/tars/config.go
@@ -67,6 +67,7 @@ type serverConfig struct {
 	PropertyReportInterval time.Duration
 	StatReportInterval     time.Duration
 	MainLoopTicker         time.Duration
+	MaxPackageLength int
 }
 
 type clientConfig struct {


### PR DESCRIPTION
增加可配置的包体大小限制（私有模版/tars/application/server的maxPackageLength字段），通过GetIntWithDef读取，默认值为iMaxLength=10485760