### PR TITLE
statf: fix memory leak by removing mStatCount

### DIFF
--- a/tars/statf.go
+++ b/tars/statf.go
@@ -20,7 +20,6 @@ type StatInfo struct {
 type StatFHelper struct {
 	lStatInfo  *list.List
 	mStatInfo  map[statf.StatMicMsgHead]statf.StatMicMsgBody
-	mStatCount map[statf.StatMicMsgHead]int
 	mlock      *sync.Mutex
 	comm       *Communicator
 	sf         *statf.StatF
@@ -36,7 +35,6 @@ func (s *StatFHelper) Init(comm *Communicator, node string) {
 	s.lStatInfoFromServer = list.New()
 	s.mlock = new(sync.Mutex)
 	s.mStatInfo = make(map[statf.StatMicMsgHead]statf.StatMicMsgBody)
-	s.mStatCount = make(map[statf.StatMicMsgHead]int)
 	s.comm = comm
 	s.sf = new(statf.StatF)
 	s.comm.StringToProxy(s.node, s.sf)
@@ -60,7 +58,6 @@ func (s *StatFHelper) addUpMsg(statList *list.List, fromServer bool) {
 			//body.WeightValue = (body.WeightValue + statInfo.Body.WeightValue)
 			//body.WeightCount = (body.WeightCount + statInfo.Body.WeightCount)
 			s.mStatInfo[statInfo.Head] = body
-			s.mStatCount[statInfo.Head]++
 		} else {
 			headMap := statInfo.Head
 			firstBody := statf.StatMicMsgBody{}
@@ -73,7 +70,6 @@ func (s *StatFHelper) addUpMsg(statList *list.List, fromServer bool) {
 			//firstBody.WeightValue = bodyList.WeightValue
 			//firstBody.WeightCount = bodyList.WeightCount
 			s.mStatInfo[headMap] = firstBody
-			s.mStatCount[headMap] = 1
 		}
 
 		n = e.Next()


### PR DESCRIPTION
目前服务上报是以【服务名、被调接口、主调IP 等】为key作为统计。但是在HTTP类型服务，由于客户端IP基本不一致，在调用量比较大的情况下，内存增长很快。

mStatCount在底层做了count，但是该字段并未上报给stat服务，所以去掉无任何影响。同时修复内存不断增长的问题。