### PR TITLE
update: enable servant to set protocol

### DIFF
--- a/tars/communicator.go
+++ b/tars/communicator.go
@@ -1,7 +1,7 @@
 package tars
 
 import (
-	s "github.com/TarsCloud/TarsGo/tars/model"
+	s "github.com/HyperLiar/TarsGo/tars/model"
 	"sync"
 )
 

--- a/tars/model/Servant.go
+++ b/tars/model/Servant.go
@@ -16,7 +16,6 @@ type Servant interface {
 		Resp *requestf.ResponsePacket) error
 	TarsSetTimeout(t int)
 	TarsSetProtocol(Protocol)
-	TarsSetVersion(ver int16)
 }
 
 type Protocol interface {

--- a/tars/model/Servant.go
+++ b/tars/model/Servant.go
@@ -15,4 +15,6 @@ type Servant interface {
 		context map[string]string,
 		Resp *requestf.ResponsePacket) error
 	TarsSetTimeout(t int)
+	TarsSetProtocol(Protocol)
+	TarsSetVersion(ver int16)
 }

--- a/tars/model/Servant.go
+++ b/tars/model/Servant.go
@@ -18,3 +18,9 @@ type Servant interface {
 	TarsSetProtocol(Protocol)
 	TarsSetVersion(ver int16)
 }
+
+type Protocol interface {
+	RequestPack(*requestf.RequestPacket) ([]byte, error)
+	ResponseUnpack([]byte) (*requestf.ResponsePacket, error)
+	ParsePackage([]byte) (int, int)
+}

--- a/tars/object.go
+++ b/tars/object.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/TarsCloud/TarsGo/tars/model"
+	"github.com/HyperLiar/TarsGo/tars/model"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/basef"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
 	"github.com/TarsCloud/TarsGo/tars/util/rtimer"

--- a/tars/object.go
+++ b/tars/object.go
@@ -18,6 +18,7 @@ type ObjectProxy struct {
 	manager  *EndpointManager
 	comm     *Communicator
 	queueLen int32
+	proto    model.Protocol
 }
 
 // Init proxy
@@ -37,6 +38,7 @@ func (obj *ObjectProxy) Invoke(ctx context.Context, msg *Message, timeout time.D
 		return errors.New("invoke queue is full:" + msg.Req.SServantName)
 	}
 	msg.Adp = adp
+	adp.obj = obj
 	atomic.AddInt32(&obj.queueLen, 1)
 	readCh := make(chan *requestf.ResponsePacket, 1)
 	adp.resp.Store(msg.Req.IRequestId, readCh)

--- a/tars/protocol/tarsprotocol.go
+++ b/tars/protocol/tarsprotocol.go
@@ -1,0 +1,51 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/TarsCloud/TarsGo/tars/protocol/codec"
+	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
+	"github.com/TarsCloud/TarsGo/tars/transport"
+)
+
+type TarsProtocol struct {
+}
+
+const (
+	iMaxLength = 10485760
+)
+
+func TafRequest(rev []byte) (int, int) {
+	if len(rev) < 4 {
+		return 0, transport.PACKAGE_LESS
+	}
+	iHeaderLen := int(binary.BigEndian.Uint32(rev[0:4]))
+	if iHeaderLen < 4 || iHeaderLen > iMaxLength {
+		return 0, transport.PACKAGE_ERROR
+	}
+	if len(rev) < iHeaderLen {
+		return 0, transport.PACKAGE_LESS
+	}
+	return iHeaderLen, transport.PACKAGE_FULL
+}
+
+func (self *TarsProtocol) RequestPack(req *requestf.RequestPacket) ([]byte, error) {
+	sbuf := bytes.NewBuffer(nil)
+	sbuf.Write(make([]byte, 4))
+	os := codec.NewBuffer()
+	req.WriteTo(os)
+	bs := os.ToBytes()
+	sbuf.Write(bs)
+	len := sbuf.Len()
+	binary.BigEndian.PutUint32(sbuf.Bytes(), uint32(len))
+	return sbuf.Bytes(), nil
+
+}
+func (self *TarsProtocol) ResponseUnpack(pkg []byte) (*requestf.ResponsePacket, error) {
+	packet := &requestf.ResponsePacket{}
+	err := packet.ReadFrom(codec.NewReader(pkg[4:]))
+	return packet, err
+}
+func (self *TarsProtocol) ParsePackage(rev []byte) (int, int) {
+	return TafRequest(rev)
+}

--- a/tars/servant.go
+++ b/tars/servant.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"tars/protocol"
 	"time"
 
 	"github.com/TarsCloud/TarsGo/tars/model"
@@ -20,7 +21,6 @@ type ServantProxy struct {
 	comm    *Communicator
 	obj     *ObjectProxy
 	timeout int
-	p       model.Protocol
 }
 
 //Init init the ServantProxy struct.
@@ -36,6 +36,7 @@ func (s *ServantProxy) Init(comm *Communicator, objName string) {
 	of.Init(comm)
 	s.timeout = s.comm.Client.AsyncInvokeTimeout
 	s.obj = of.GetObjectProxy(objName)
+	s.obj.proto = &protocol.TarsProtocol{}
 }
 
 //TarsSetTimeout sets the timeout for client calling the server , which is in ms.
@@ -44,7 +45,7 @@ func (s *ServantProxy) TarsSetTimeout(t int) {
 }
 
 func (s *ServantProxy) TarsSetProtocol(p model.Protocol) {
-	s.p = p
+	s.obj.proto = p
 }
 
 //Tars_invoke is use for client inoking server.

--- a/tars/servant.go
+++ b/tars/servant.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/TarsCloud/TarsGo/tars/model"
+	"github.com/HyperLiar/TarsGo/tars/model"
 	"github.com/HyperLiar/TarsGo/tars/protocol"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/basef"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"

--- a/tars/servant.go
+++ b/tars/servant.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/TarsCloud/TarsGo/tars/model"
-	"github.com/TarsCloud/TarsGo/tars/protocol"
+	"github.com/HyperLiar/TarsGo/tars/protocol"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/basef"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
 	"github.com/TarsCloud/TarsGo/tars/util/tools"

--- a/tars/servant.go
+++ b/tars/servant.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/TarsCloud/TarsGo/tars/model"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/basef"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
 	"github.com/TarsCloud/TarsGo/tars/util/tools"
@@ -19,6 +20,7 @@ type ServantProxy struct {
 	comm    *Communicator
 	obj     *ObjectProxy
 	timeout int
+	p       model.Protocol
 }
 
 //Init init the ServantProxy struct.
@@ -39,6 +41,10 @@ func (s *ServantProxy) Init(comm *Communicator, objName string) {
 //TarsSetTimeout sets the timeout for client calling the server , which is in ms.
 func (s *ServantProxy) TarsSetTimeout(t int) {
 	s.timeout = t
+}
+
+func (s *ServantProxy) TarsSetProtocol(p model.Protocol) {
+	s.p = p
 }
 
 //Tars_invoke is use for client inoking server.

--- a/tars/servant.go
+++ b/tars/servant.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"tars/protocol"
 	"time"
 
 	"github.com/TarsCloud/TarsGo/tars/model"

--- a/tars/util/rogger/logger_test.go
+++ b/tars/util/rogger/logger_test.go
@@ -1,7 +1,6 @@
 package rogger
 
 import (
-	"github.com/TarsCloud/TarsGo/tars/util/logger"
 	"testing"
 	"time"
 )
@@ -48,20 +47,4 @@ func BenchmarkRogger(b *testing.B) {
 		lg.Error("ERROR")
 	}
 	FlushLogger()
-}
-
-//BenchmarkOldLogger benchmark old rogger writes.
-func BenchmarkOldLogger(b *testing.B) {
-	bs := make([]byte, 1024)
-	longmsg := string(bs)
-	lg := logger.GetLogger()
-	lg.SetLevel(logger.DEBUG)
-	lg.SetConsole(false)
-	lg.SetRollingFile("./logs", "oldlog", 10, 100, logger.MB)
-	for i := 0; i < b.N; i++ {
-		lg.Debug("debugxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-		lg.Info(longmsg)
-		lg.Warn("warn")
-		lg.Error("ERROR")
-	}
 }

--- a/tars/util/rogger/logger_test.go
+++ b/tars/util/rogger/logger_test.go
@@ -1,7 +1,7 @@
 package rogger
 
 import (
-	"tars/util/logger"
+	"github.com/TarsCloud/TarsGo/tars/util/logger"
 	"testing"
 	"time"
 )


### PR DESCRIPTION
Hi, I'm an software enginner from tencent and our work require to set protocol to Servant. In out internal we can not use go mod to download deps of go. And in Tars, TarsSetProtocol  has been defined but not been claimed in interface. So I made a fork and suggest this issue.

-------------------------------------------------------------
Hi, 我是腾讯的一名软件工程师。我们项目使用了内部协议，需要设置到Servant。内部版本无法使用go mod下载依赖，而开源版本servant具有相关的方法，却没有在接口中定义，我这边手动加上了，希望能尽快merge。