### PR TITLE
[*] 当有obj未配置时，让其他所有配置的obj正常run

### DIFF
--- a/tars/application.go
+++ b/tars/application.go
@@ -244,7 +244,7 @@ func Run() {
 		s := goSvrs[obj]
 		if s == nil {
 			TLOG.Debug("Obj not found", obj)
-			break
+			continue
 		}
 		TLOG.Debug("Run", obj, s.GetConfig())
 		go func(obj string) {


### PR DESCRIPTION
目前break loop的方式，当一个服务有多个obj时，如果有一个obj未配置，会导致改obj后面的所有obj不被启动