### PR TITLE
Fix empty-stringed-error when object gets Tars eroror code without me…

### DIFF
--- a/tars/object.go
+++ b/tars/object.go
@@ -56,6 +56,9 @@ func (obj *ObjectProxy) Invoke(ctx context.Context, msg *Message, timeout time.D
 		return fmt.Errorf("%s|%s|%d", "request timeout", msg.Req.SServantName, msg.Req.IRequestId)
 	case msg.Resp = <-readCh:
 		if msg.Resp.IRet != basef.TARSSERVERSUCCESS {
+			if msg.Resp.SResultDesc == "" {
+				return fmt.Errorf("basef error code %d", msg.Resp.IRet)
+			}
 			return errors.New(msg.Resp.SResultDesc)
 		}
 		TLOG.Debug("recv msg succ ", msg.Req.IRequestId)


### PR DESCRIPTION
发现采用 TarsGo client 向 TarsCpp server 请求时，如果并发突增，会导致出现 TARSSERVERQUEUETIMEOUT 错误。但此时的 msg.Resp.SResultDesc 是空的，导致调用方调用 err.Error() 只能拿到 ""，这会让程序员非常困惑。

It is found that when tarsgo client send request  to tarscpp server, if concurrency suddenly increases, TARSSERVERQUEUETIMEOUT error will occur. But at this time, msg.resp.sresultdesc is empty, which causes the caller to call err. Error() only to get "", which will make the programmer very confused.