### PR TITLE
zipkin版本更新

### DIFF
--- a/examples/ZipkinTraceClient/ZipkinTraceClient.go
+++ b/examples/ZipkinTraceClient/ZipkinTraceClient.go
@@ -29,7 +29,8 @@ func main() { //Init servant
 	tars.RegisterServerFilter(sf)
 	cfg := tars.GetServerConfig() //Get Config File Object
 	port := cfg.Adapters[cfg.App+"."+cfg.Server+".ZipkinClientObjAdapter"].Endpoint.Port
-	zipkintracing.Init("http://127.0.0.1:9411/api/v1/spans", true, true, true, strconv.Itoa(int(port)), cfg.App+"."+cfg.Server)
+	hostPort := cfg.Adapters[cfg.App+"."+cfg.Server+".ZipkinClientObjAdapter"].Endpoint.Host + ":" + strconv.Itoa(int(port))
+	zipkintracing.Init("http://127.0.0.1:9411/api/v2/spans", true, true, true, hostPort, cfg.App+"."+cfg.Server)
 	app.AddServantWithContext(imp, cfg.App+"."+cfg.Server+".ZipkinClientObj") //Register Servant
 	tars.Run()
 }

--- a/examples/ZipkinTraceServer/ZipkinTraceServer.go
+++ b/examples/ZipkinTraceServer/ZipkinTraceServer.go
@@ -19,7 +19,8 @@ func main() { //Init servant
 
 	cfg := tars.GetServerConfig() //Get Config File Object
 	port := cfg.Adapters[cfg.App+"."+cfg.Server+".ZipkinTraceObjAdapter"].Endpoint.Port
-	zipkintracing.Init("http://127.0.0.1:9411/api/v1/spans", true, true, true, strconv.Itoa(int(port)), cfg.App+"."+cfg.Server)
+	hostPort := cfg.Adapters[cfg.App+"."+cfg.Server+".ZipkinTraceObjAdapter"].Endpoint.Host + ":" + strconv.Itoa(int(port))
+	zipkintracing.Init("http://127.0.0.1:9411/api/v2/spans", true, true, true, hostPort, cfg.App+"."+cfg.Server)
 	app.AddServantWithContext(imp, cfg.App+"."+cfg.Server+".ZipkinTraceObj") //Register Servant
 	tars.Run()
 }

--- a/tars/plugin/zipkintracing/zipkintracing.go
+++ b/tars/plugin/zipkintracing/zipkintracing.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/TarsCloud/TarsGo/tars"
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	oplog "github.com/opentracing/opentracing-go/log"
-	zipkin "github.com/openzipkin/zipkin-go-opentracing"
+	zipkinot "github.com/openzipkin-contrib/zipkin-go-opentracing"
+	"github.com/openzipkin/zipkin-go"
+	zipkinhttp "github.com/openzipkin/zipkin-go/reporter/http"
 )
 
 var logger = tars.GetLogger("tracing")
@@ -19,22 +21,28 @@ var logger = tars.GetLogger("tracing")
 //Init is use to init opentracing and zipkin
 func Init(zipkinHTTPEndpoint string, sameSpan bool, traceID128Bit bool, debug bool,
 	hostPort, serviceName string) {
-	//create collector
-	collector, err := zipkin.NewHTTPCollector(zipkinHTTPEndpoint)
+
+	// set up a span reporter
+	reporter := zipkinhttp.NewReporter(zipkinHTTPEndpoint)
+	//defer reporter.Close()
+
+	// create our local service endpoint
+	endpoint, err := zipkin.NewEndpoint(serviceName, hostPort)
 	if err != nil {
-		log.Fatal("Fail to create Zipkin HTTP collector:", err)
+		log.Fatalf("unable to create local endpoint: %+v\n", err)
 	}
-	//create recorder
-	recorder := zipkin.NewRecorder(collector, debug, hostPort, serviceName)
-	tracer, err := zipkin.NewTracer(
-		recorder,
-		zipkin.ClientServerSameSpan(sameSpan),
-		zipkin.TraceID128Bit(traceID128Bit),
-	)
+
+	// initialize our tracer
+	nativeTracer, err := zipkin.NewTracer(reporter, zipkin.WithLocalEndpoint(endpoint))
 	if err != nil {
-		log.Fatal("Fail to NewTracer")
+		log.Fatalf("unable to create tracer: %+v\n", err)
 	}
-	opentracing.InitGlobalTracer(tracer)
+
+	// use zipkin-go-opentracing to wrap our tracer
+	tracer := zipkinot.Wrap(nativeTracer)
+
+	// optionally set as Global OpenTracing tracer instance
+	opentracing.SetGlobalTracer(tracer)
 }
 
 //ZipkinClientFilter gets tars client filter for zipkin opentracing.


### PR DESCRIPTION
接入方：hostport固定格式需要改为:
```
hostPort := cfg.Adapters[cfg.App+"."+cfg.Server+".GoWebObjAdapter"].Endpoint.Host + ":" + strconv.Itoa(int(port))
zipkintracing.Init("http://127.0.0.1:9411/api/v2/spans", true, true, true, hostPort, cfg.App+"."+cfg.Server)

```