### PR TITLE
tars2go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,6 @@ module github.com/TarsCloud/TarsGo
 go 1.13
 
 require (
-	github.com/Shopify/sarama v1.26.1 // indirect
-	github.com/apache/thrift v0.13.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.0 // indirect
-	github.com/gogo/protobuf v1.3.1 // indirect
-	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
-	github.com/openzipkin/zipkin-go v0.2.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,12 @@ module github.com/TarsCloud/TarsGo
 go 1.13
 
 require (
+	github.com/Shopify/sarama v1.26.1 // indirect
+	github.com/apache/thrift v0.13.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.0 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
+	github.com/openzipkin/zipkin-go v0.2.2 // indirect
 )

--- a/tars/application.go
+++ b/tars/application.go
@@ -266,7 +266,11 @@ func Run() {
 				lisDone.Done()
 				err = s.Serve(ln)
 				if err != nil {
-					teerDown(fmt.Errorf("%s server stop: %v", obj, err))
+					if err == http.ErrServerClosed {
+						TLOG.Infof("%s http server stop: %v", obj, err)
+					} else {
+						teerDown(fmt.Errorf("%s server stop: %v", obj, err))
+					}
 				}
 			}(obj)
 			continue

--- a/tars/filter.go
+++ b/tars/filter.go
@@ -8,12 +8,12 @@ import (
 )
 
 type filters struct {
-	cf ClientFilter
-	preCfs []ClientFilter
+	cf      ClientFilter
+	preCfs  []ClientFilter
 	postCfs []ClientFilter
 
-	sf ServerFilter
-	preSfs []ServerFilter
+	sf      ServerFilter
+	preSfs  []ServerFilter
 	postSfs []ServerFilter
 }
 

--- a/tars/panic.go
+++ b/tars/panic.go
@@ -3,7 +3,7 @@ package tars
 import (
 	"fmt"
 	"os"
-	
+
 	"github.com/TarsCloud/TarsGo/tars/util/debug"
 	"github.com/TarsCloud/TarsGo/tars/util/rogger"
 )

--- a/tars/protocol/tarsprotocol.go
+++ b/tars/protocol/tarsprotocol.go
@@ -8,7 +8,6 @@ import (
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
 )
 
-
 func TarsRequest(rev []byte, maxLen int) (int, int) {
 	if len(rev) < 4 {
 		return 0, PACKAGE_LESS

--- a/tars/tools/tars2go/gen_go.go
+++ b/tars/tools/tars2go/gen_go.go
@@ -1412,6 +1412,9 @@ func (gen *GenGo) genIFDispatch(itf *InterfaceInfo) {
 		SResultDesc:  "",
 		Context:      _context,
 	}
+
+	_ = _is
+	_ = _os
 	_ = length
 	_ = have
 	_ = ty

--- a/tars/tools/tars2go/gen_go.go
+++ b/tars/tools/tars2go/gen_go.go
@@ -59,7 +59,7 @@ func path2ProtoName(path string) string {
 	} else {
 		iBegin++
 	}
-	iEnd := strings.LastIndex(path, ".jce")
+	iEnd := strings.LastIndex(path, ".tars")
 	if iEnd == -1 {
 		iEnd = len(path)
 	}

--- a/tars/transport/udphandler.go
+++ b/tars/transport/udphandler.go
@@ -67,7 +67,7 @@ func (h *udpHandler) Handle() error {
 			current.SetClientIPWithContext(ctx, udpAddr.IP.String())
 			current.SetClientPortWithContext(ctx, strconv.Itoa(udpAddr.Port))
 			current.SetRecvPkgTsFromContext(ctx, time.Now().UnixNano()/1e6)
-			
+
 			atomic.AddInt32(&h.ts.numInvoke, 1)
 			rsp := h.ts.invoke(ctx, pkg) // no need to check package
 
@@ -75,7 +75,7 @@ func (h *udpHandler) Handle() error {
 			if !ok {
 				TLOG.Error("Failed to GetPacketTypeFromContext")
 			}
-			
+
 			if cPacketType == basef.TARSONEWAY {
 				atomic.AddInt32(&h.ts.numInvoke, -1)
 				return

--- a/tars/util/conf/conf.go
+++ b/tars/util/conf/conf.go
@@ -146,9 +146,9 @@ func (e *elem) getValue(path string) (string, error) {
 
 // Conf struct for parse xml-like tars config file.
 type Conf struct {
-	content []byte 		// content for storing data
-	mutex   *sync.RWMutex 	// mutex for multi goroutines
-	root    *elem 		// root is the root element
+	content []byte        // content for storing data
+	mutex   *sync.RWMutex // mutex for multi goroutines
+	root    *elem         // root is the root element
 }
 
 // New  returns an new Conf struct.

--- a/tars/util/current/clientcurrent.go
+++ b/tars/util/current/clientcurrent.go
@@ -13,8 +13,8 @@ type ClientCurrent struct {
 	isTimeout bool
 	timeout   int //in ms
 
-	serverIP    string
-	serverPort  string
+	serverIP   string
+	serverPort string
 }
 
 func newCientCurrent() *ClientCurrent {

--- a/tars/util/current/tarscurrent.go
+++ b/tars/util/current/tarscurrent.go
@@ -6,7 +6,7 @@ type tarsCurrentKey int64
 
 var tcKey = tarsCurrentKey(0x484900)
 
-// Current contains message for the specify request. 
+// Current contains message for the specify request.
 // This current is used for server side.
 type Current struct {
 	clientIP    string

--- a/tars/util/endpoint/convert.go
+++ b/tars/util/endpoint/convert.go
@@ -9,14 +9,14 @@ func Tars2endpoint(end endpointf.EndpointF) Endpoint {
 		proto = "udp"
 	}
 	e := Endpoint{
-		Host:      end.Host,
-		Port:      int32(end.Port),
-		Timeout:   int32(end.Timeout),
-		Istcp:     end.Istcp,
-		Proto:     proto,
-		Bind:      "",
+		Host:    end.Host,
+		Port:    int32(end.Port),
+		Timeout: int32(end.Timeout),
+		Istcp:   end.Istcp,
+		Proto:   proto,
+		Bind:    "",
 		//Container: end.ContainerName,
-		SetId:     end.SetId,
+		SetId: end.SetId,
 	}
 	e.Key = e.String()
 	return e
@@ -25,12 +25,12 @@ func Tars2endpoint(end endpointf.EndpointF) Endpoint {
 // Endpoint2tars transfer Endpoint to endpointf.EndpointF
 func Endpoint2tars(end Endpoint) endpointf.EndpointF {
 	return endpointf.EndpointF{
-		Host:          end.Host,
-		Port:          int32(end.Port),
-		Timeout:       int32(end.Timeout),
-		Istcp:         end.Istcp,
+		Host:    end.Host,
+		Port:    int32(end.Port),
+		Timeout: int32(end.Timeout),
+		Istcp:   end.Istcp,
 		//ContainerName: end.Container,
-		SetId:         end.SetId,
+		SetId: end.SetId,
 	}
 }
 

--- a/tars/util/rogger/logger.go
+++ b/tars/util/rogger/logger.go
@@ -25,7 +25,7 @@ var (
 	logLevel = DEBUG
 	colored  = false
 
-	logQueue      = make(chan *logValue, 10000)
+	logQueue    = make(chan *logValue, 10000)
 	loggerMutex sync.Mutex
 	loggerMap   = make(map[string]*Logger)
 	writeDone   = make(chan bool)

--- a/tars/util/tools/parser.go
+++ b/tars/util/tools/parser.go
@@ -3,8 +3,8 @@ package tools
 import (
 	"strconv"
 	"strings"
-	"unicode"
 	"time"
+	"unicode"
 )
 
 const (


### PR DESCRIPTION
tars2go: fix compile error when interface has no args
tars2go: fix no sturct define code
log: No error log when http service exits normally