### PR TITLE
fix _funRet_ type problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - Auto service discovery.
 - TCP/UDP/Http server & Client.
 - The support of local logging and remote logging.
-- The support of statistical reporting,  property statistics,and anormaly reporting.
+- The support of statistical reporting,  property statistics,and anomaly reporting.
 - The support of set division.
 - The support of protocol buffers. See more in [pb2tarsgo](tars/tools/pb2tarsgo/README.md)
 - The support of filter.
@@ -628,7 +628,7 @@ after every client call server ，no matter success or failure. And the success 
 > * The reported data is reported regularly and can be set in the configuration of the communicator.
 
 
-### 7 Anormaly reporting
+### 7 Anomaly reporting
 For better monitoring, the TARS framework supports reporting abnormal situation directly to tarsnotify in the program and can be viewed on the WEB management page.
 
 The framework provides three macros to report different kinds of exceptions:

--- a/tars/tools/tars2go/gen_go.go
+++ b/tars/tools/tars2go/gen_go.go
@@ -1553,9 +1553,11 @@ func (gen *GenGo) genSwitchCase(tname string, fun *FunInfo) {
 	if tarsReq.IVersion == basef.TARSVERSION {
 	_os.Reset()
 	`)
+
 	if fun.HasRet {
+		funRetType := gen.genType(fun.RetType)
 		c.WriteString(`
-		err = _os.Write_int32(_funRet_, 0)
+		err = _os.Write_`+funRetType+`(_funRet_, 0)
 		if err != nil {
 			return err
 		}		
@@ -1579,9 +1581,10 @@ _tupRsp_ := tup.NewUniAttribute()
 `)
 
 	if fun.HasRet {
+		funRetType := gen.genType(fun.RetType)
 		c.WriteString(`
 		_os.Reset()
-		err = _os.Write_int32(_funRet_, 0)
+		err = _os.Write_`+funRetType+`(_funRet_, 0)
 		if err != nil {
 			return err
 		}

--- a/tars/tools/tars2go/main_test.go
+++ b/tars/tools/tars2go/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGenGo_Gen(t *testing.T) {
+	var filename = "/home/yifabao/go/src/fabaoyi.com/QuwanyunApp/PhoneRedPacketServer/ReportInfo.tars"
+	gOutdir = "/home/yifabao/go/src/fabaoyi.com/QuwanyunApp/PhoneRedPacketServer/tars-protocol"
+	gModule = "fabaoyi.com/QuwanyunApp/PhoneRedPacketServer"
+	gen := NewGenGo(filename, gModule, gOutdir)
+	gen.I = gImports
+	gen.tarsPath = gTarsPath
+	gen.Gen()
+}


### PR DESCRIPTION
1.1.4  tars2go 生成代码时对返回值类型未做判断,都是Write_int32, int32 替换为获取的函数返回类型即可