### PR TITLE
add support for HTTPS and func AddHttpsServant(#232)

### DIFF
--- a/tars/application.go
+++ b/tars/application.go
@@ -272,7 +272,15 @@ func Run() {
 				}
 
 				lisDone.Done()
-				err = s.Serve(ln)
+				configHasCert := s.TLSConfig != nil 
+				if configHasCert {
+					configHasCert = len(s.TLSConfig.Certificates) > 0 || s.TLSConfig.GetCertificate != nil 
+				}
+				if configHasCert {
+					err = s.ServeTLS(ln,"","")
+				} else {
+					err = s.Serve(ln)
+				}
 				if err != nil {
 					if err == http.ErrServerClosed {
 						TLOG.Infof("%s http server stop: %v", obj, err)

--- a/tars/servanthandle.go
+++ b/tars/servanthandle.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"crypto/tls"	
 
 	"github.com/TarsCloud/TarsGo/tars/transport"
 )
@@ -85,4 +86,47 @@ func AddServantWithProtocol(proto transport.ServerProtocol, obj string) {
 	TLOG.Debug("add:", cfg)
 	s := transport.NewTarsServer(proto, cfg)
 	goSvrs[obj] = s
+}
+
+// AddHttpsServant add https servant handler with default exceptionStatusChecker for obj.
+func AddHttpsServant(mux *TarsHttpMux, obj, certFile, keyFile string) {
+	AddHttpsServantWithExceptionStatusChecker(mux, obj, certFile, keyFile, DefaultExceptionStatusChecker)
+}
+
+// AddHttpsServantWithExceptionStatusChecker add https servant handler with exceptionStatusChecker for obj.
+func AddHttpsServantWithExceptionStatusChecker(mux *TarsHttpMux, obj, certFile, keyFile string, exceptionStatusChecker func(int) bool) {
+	cfg, ok := tarsConfig[obj]
+	if !ok {
+		ReportNotifyInfo(NOTIFY_ERROR, "servant obj name not found:"+obj)
+		TLOG.Debug("servant obj name not found:", obj)
+		panic(ok)
+	}
+	TLOG.Debug("add http server:", cfg)
+	objRunList = append(objRunList, obj)
+	appConf := GetServerConfig()
+	addrInfo := strings.SplitN(cfg.Address, ":", 2)
+	var port int
+	if len(addrInfo) == 2 {
+		port, _ = strconv.Atoi(addrInfo[1])
+	}
+	httpConf := &TarsHttpConf{
+		Container:              appConf.Container,
+		AppName:                fmt.Sprintf("%s.%s", appConf.App, appConf.Server),
+		Version:                appConf.Version,
+		IP:                     addrInfo[0],
+		Port:                   int32(port),
+		SetId:                  appConf.Setdivision,
+		ExceptionStatusChecker: exceptionStatusChecker,
+	}
+	mux.SetConfig(httpConf)
+	s := &http.Server{Addr: cfg.Address, Handler: mux}
+	s.TLSConfig = &tls.Config{Certificates:make([]tls.Certificate, 1)}
+	var err error
+	s.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		ReportNotifyInfo(NOTIFY_ERROR, "servant can't load X509 Key Pair from file:"+certFile+","+keyFile)
+		TLOG.Debug("servant can't load X509 Key Pair from file:"+certFile+","+keyFile)
+		panic(err)
+	}
+	httpSvrs[obj] = s
 }


### PR DESCRIPTION
Add new feature ： support for HTTPS. If you want a HTTPS servant， you'll only use func AddHttpsServant instead of func AddHttpServant. And the func AddHttpsServant have more parameters: certFile, keyFile.