### PR TITLE
tars: fix various problems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,10 @@ module github.com/TarsCloud/TarsGo
 go 1.13
 
 require (
-	github.com/Shopify/sarama v1.26.4 // indirect
-	github.com/apache/thrift v0.13.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.0 // indirect
-	github.com/gogo/protobuf v1.3.1 // indirect
-	github.com/golang/protobuf v1.4.2
-	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
+	github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/stretchr/testify v1.6.1
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/tars/application.go
+++ b/tars/application.go
@@ -134,7 +134,7 @@ func initConfig() {
 	svrCfg.WriteTimeout = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<writetimeout>", WriteTimeout))
 	svrCfg.HandleTimeout = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<handletimeout>", HandleTimeout))
 	svrCfg.IdleTimeout = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<idletimeout>", IdleTimeout))
-	svrCfg.ZombileTimeout = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<zombiletimeout>", ZombileTimeout))
+	svrCfg.ZombieTimeout = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<zombietimeout>", ZombieTimeout))
 	svrCfg.QueueCap = c.GetIntWithDef("/tars/application/server<queuecap>", QueueCap)
 	svrCfg.GracedownTimeout = tools.ParseTimeOut(c.GetIntWithDef("/tars/application/server<gracedowntimeout>", GracedownTimeout))
 
@@ -485,7 +485,7 @@ func mainloop() {
 					continue
 				}
 				if s, ok := goSvrs[adapter.Obj]; ok {
-					if !s.IsZombie(GetServerConfig().ZombileTimeout) {
+					if !s.IsZombie(GetServerConfig().ZombieTimeout) {
 						ha.KeepAlive(name)
 					}
 				}

--- a/tars/config.go
+++ b/tars/config.go
@@ -51,13 +51,13 @@ type serverConfig struct {
 	Enableset   bool
 	Setdivision string
 	//add server timeout
-	AcceptTimeout  time.Duration
-	ReadTimeout    time.Duration
-	WriteTimeout   time.Duration
-	HandleTimeout  time.Duration
-	IdleTimeout    time.Duration
-	ZombileTimeout time.Duration
-	QueueCap       int
+	AcceptTimeout time.Duration
+	ReadTimeout   time.Duration
+	WriteTimeout  time.Duration
+	HandleTimeout time.Duration
+	IdleTimeout   time.Duration
+	ZombieTimeout time.Duration
+	QueueCap      int
 	//add tcp config
 	TCPReadBuffer  int
 	TCPWriteBuffer int

--- a/tars/nodef.go
+++ b/tars/nodef.go
@@ -22,12 +22,10 @@ func (n *NodeFHelper) SetNodeInfo(comm *Communicator, node string, app string, s
 	n.sf = new(nodef.ServerF)
 	comm.StringToProxy(node, n.sf)
 	n.si = nodef.ServerInfo{
-		app,
-		server,
-		int32(os.Getpid()),
-		"",
-		//"tars",
-		//container,
+		Application: app,
+		ServerName:  server,
+		Pid:         int32(os.Getpid()),
+		Adapter:     "",
 	}
 }
 

--- a/tars/notifyf.go
+++ b/tars/notifyf.go
@@ -26,14 +26,14 @@ func (n *NotifyHelper) SetNotifyInfo(comm *Communicator, notify string, app stri
 		set = v
 	}
 	n.tm = notifyf.ReportInfo{
-		0,
-		app,
-		set,
-		container,
-		server,
-		"",
-		"",
-		0,
+		EType:      0,
+		SApp:       app,
+		SSet:       set,
+		SContainer: container,
+		SServer:    server,
+		SMessage:   "",
+		SThreadId:  "",
+		ELevel:     0,
 	}
 }
 

--- a/tars/protocol/codec/codec.go
+++ b/tars/protocol/codec/codec.go
@@ -171,7 +171,7 @@ func (b *Buffer) Write_slice_int8(data []int8) error {
 }
 
 // Write_bytes write []byte to the buffer
-func (b *Buffer) Write_bytes(data []byte) error  {
+func (b *Buffer) Write_bytes(data []byte) error {
 	_, err := b.buf.Write(data)
 	return err
 }

--- a/tars/protocol/codec/codec_test.go
+++ b/tars/protocol/codec/codec_test.go
@@ -496,7 +496,6 @@ func TestBuffer_getTypeStr(t *testing.T) {
 	}
 }
 
-
 func TestReader_Reset(t *testing.T) {
 	writer := NewBuffer()
 	err := writer.Write_bytes([]byte("test"))
@@ -623,7 +622,7 @@ func TestReader_SkipToNoCheck(t *testing.T) {
 
 	reader := r(prepareWrite())
 	err, exists, _ := reader.SkipToNoCheck(3, true)
-	if err == nil || exists{
+	if err == nil || exists {
 		t.Error("SkipToNoCheck failed.expecting error, but got nil\n")
 	}
 	if err != nil && err.Error() != "Can not find Tag 3. But require. tagCur: 5, tyCur: 0" {

--- a/tars/protocol/res/basef/BaseF_const.go
+++ b/tars/protocol/res/basef/BaseF_const.go
@@ -7,7 +7,7 @@ package basef
 const (
 	TARSVERSION             int16 = 0x01
 	TUPVERSION              int16 = 0x03
-	JSONVERSION				int16 = 0x05
+	JSONVERSION             int16 = 0x05
 	TARSNORMAL              int8  = 0x00
 	TARSONEWAY              int8  = 0x01
 	TARSSERVERSUCCESS       int32 = 0

--- a/tars/protocol/tarsprotocol.go
+++ b/tars/protocol/tarsprotocol.go
@@ -6,10 +6,9 @@ import (
 	"github.com/TarsCloud/TarsGo/tars/protocol/res/requestf"
 )
 
-
 var maxPackageLength int = 10485760
 
-// SetMaxPackageLength sets the max length of tars packet 
+// SetMaxPackageLength sets the max length of tars packet
 func SetMaxPackageLength(len int) {
 	maxPackageLength = len
 }
@@ -28,7 +27,7 @@ func TarsRequest(rev []byte) (int, int) {
 	return iHeaderLen, PACKAGE_FULL
 }
 
-type TarsProtocol struct {}
+type TarsProtocol struct{}
 
 func (p *TarsProtocol) RequestPack(req *requestf.RequestPacket) ([]byte, error) {
 	os := codec.NewBuffer()

--- a/tars/protocol/tarsprotocol_test.go
+++ b/tars/protocol/tarsprotocol_test.go
@@ -14,7 +14,7 @@ func TestSetMaxPackageLength(t *testing.T) {
 	type args struct {
 		len int
 	}
-	tests := []int {1,2,3,4,5,10,100,1000,10230,100042, 1000523}
+	tests := []int{1, 2, 3, 4, 5, 10, 100, 1000, 10230, 100042, 1000523}
 	for _, tt := range tests {
 		t.Run("normal", func(t *testing.T) {
 			SetMaxPackageLength(tt)
@@ -45,40 +45,40 @@ func TestTarsProtocol_ParsePackage(t *testing.T) {
 				MaxPackageLength: 8,
 			},
 			args: args{
-				[]byte{1,3},
+				[]byte{1, 3},
 			},
-			want:0,
-			want1:0,
-		},{
+			want:  0,
+			want1: 0,
+		}, {
 			name: "Package error",
 			fields: fields{
 				MaxPackageLength: 5,
 			},
 			args: args{
-				[]byte{0,0,0,35,84,64,55},
+				[]byte{0, 0, 0, 35, 84, 64, 55},
 			},
-			want:0,
-			want1:2,
-		},{
+			want:  0,
+			want1: 2,
+		}, {
 			name: "Package less2",
 			fields: fields{
 				MaxPackageLength: 5,
 			},
 			args: args{
-				[]byte{0,0,0,5},
+				[]byte{0, 0, 0, 5},
 			},
-			want:0,
-			want1:0,
-		},{
+			want:  0,
+			want1: 0,
+		}, {
 			name: "Package full",
 			fields: fields{
 				MaxPackageLength: 1000000,
 			},
 			args: args{
-				[]byte{0,0,0,8,2,0,0,1,1},
+				[]byte{0, 0, 0, 8, 2, 0, 0, 1, 1},
 			},
-			want:8,
-			want1:1,
+			want:  8,
+			want1: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -97,16 +97,16 @@ func TestTarsProtocol_ParsePackage(t *testing.T) {
 }
 func TestTarsProtocol_RequestPack(t *testing.T) {
 	req := &requestf.RequestPacket{
-		IVersion: basef.TARSVERSION,
-		CPacketType: 1,
+		IVersion:     basef.TARSVERSION,
+		CPacketType:  1,
 		IMessageType: 2,
-		IRequestId: 3,
+		IRequestId:   3,
 		SServantName: "unittest",
-		SFuncName: "RequestPack",
-		SBuffer: []int8{1,2,3,4,5,6,7,8},
-		ITimeout: 4,
-		Context: map[string]string{"hello":"tars"},
-		Status: map[string]string{"hello":"tarser"},
+		SFuncName:    "RequestPack",
+		SBuffer:      []int8{1, 2, 3, 4, 5, 6, 7, 8},
+		ITimeout:     4,
+		Context:      map[string]string{"hello": "tars"},
+		Status:       map[string]string{"hello": "tarser"},
 	}
 	p := &TarsProtocol{}
 	pack, err := p.RequestPack(req)
@@ -129,10 +129,10 @@ func TestTarsProtocol_ResponseUnpack(t *testing.T) {
 		IRequestId:   2,
 		IMessageType: 3,
 		IRet:         4,
-		SBuffer:      []int8{1,2,3,4,5,6,7,8},
-		Status:       map[string]string{"hello":"tarser"},
+		SBuffer:      []int8{1, 2, 3, 4, 5, 6, 7, 8},
+		Status:       map[string]string{"hello": "tarser"},
 		SResultDesc:  "succ",
-		Context:      map[string]string{"hello":"tars"},
+		Context:      map[string]string{"hello": "tars"},
 	}
 	buf := codec.NewBuffer()
 	err := resp.WriteTo(buf)

--- a/tars/protocol/tup/tup.go
+++ b/tars/protocol/tup/tup.go
@@ -9,11 +9,11 @@ import (
 
 type TarsStructIF interface {
 	WriteBlock(os *codec.Buffer, tag byte) error
-    ReadBlock(is *codec.Reader, tag byte, require bool) error	
+	ReadBlock(is *codec.Reader, tag byte, require bool) error
 }
 
 type UniAttribute struct {
-	_data 	map[string][]byte
+	_data map[string][]byte
 	//os 		codec.Buffer
 	//is 		codec.Reader
 }
@@ -22,13 +22,12 @@ func NewUniAttribute() *UniAttribute {
 	return &UniAttribute{_data: make(map[string][]byte)}
 }
 
-
 func (u *UniAttribute) PutBuffer(k string, buf []byte) {
 	u._data[k] = make([]byte, len(buf))
 	copy(u._data[k], buf)
 }
 
-func (u *UniAttribute) GetBuffer(k string, buf *[]byte) error  {
+func (u *UniAttribute) GetBuffer(k string, buf *[]byte) error {
 	var err error
 	var ok bool = false
 	if *buf, ok = u._data[k]; !ok {
@@ -71,10 +70,10 @@ func (u *UniAttribute) Encode(os *codec.Buffer) error {
 		}
 	}
 
-	return  err
+	return err
 }
 
-func (u *UniAttribute) Decode(is *codec.Reader) error  {
+func (u *UniAttribute) Decode(is *codec.Reader) error {
 	err, have := is.SkipTo(codec.MAP, 0, false)
 	if err != nil {
 		return err
@@ -128,10 +127,10 @@ func (u *UniAttribute) Decode(is *codec.Reader) error  {
 		}
 	}
 
-	return  err
+	return err
 }
 
-func (u *UniAttribute) putBase(data interface{}, os *codec.Buffer) error  {
+func (u *UniAttribute) putBase(data interface{}, os *codec.Buffer) error {
 	var err error
 	//os := codec.NewBuffer()
 	switch data.(type) {
@@ -162,11 +161,11 @@ func (u *UniAttribute) putBase(data interface{}, os *codec.Buffer) error  {
 	default:
 		err = fmt.Errorf("Tup Put Error: not support type!")
 	}
-	
+
 	return err
 }
 
-func (u *UniAttribute) doPut(data interface{}, os *codec.Buffer) error  {
+func (u *UniAttribute) doPut(data interface{}, os *codec.Buffer) error {
 	var err error
 	switch reflect.TypeOf(data).Kind() {
 	case reflect.Slice, reflect.Array:
@@ -237,14 +236,14 @@ func (u *UniAttribute) doPut(data interface{}, os *codec.Buffer) error  {
 				}
 			}
 		}
-		
+
 	default:
 		err = u.putBase(data, os)
 	}
 	return err
 }
 
-func (u *UniAttribute) Put(k string, data interface{}) error  {
+func (u *UniAttribute) Put(k string, data interface{}) error {
 	var err error
 	os := codec.NewBuffer()
 	err = u.doPut(data, os)
@@ -291,17 +290,17 @@ func (u *UniAttribute) getBase(data interface{}, is *codec.Reader) error {
 	// } else {
 	// 	err = fmt.Errorf("Tup Get Error: donot find key: %s!", k)
 	// }
-	
+
 	return err
 }
 
-func (u *UniAttribute)doGet(data interface{}, is *codec.Reader) error {
+func (u *UniAttribute) doGet(data interface{}, is *codec.Reader) error {
 	var err error
 	//vOF := reflect.ValueOf(data).Elem()
 	switch reflect.TypeOf(data).Kind() {
 	case reflect.Slice:
 		fmt.Println("get slice ...")
-		
+
 		err, have, ty := is.SkipToNoCheck(0, false)
 		if err != nil {
 			return err

--- a/tars/setting.go
+++ b/tars/setting.go
@@ -25,8 +25,8 @@ const (
 	HandleTimeout = 0
 	//IdleTimeout idle timeout,defaultvalue is 600000 milliseconds
 	IdleTimeout = 600000
-	//ZombileTimeout zombile timeout,defaultvalue is 10000 milliseconds
-	ZombileTimeout = 10000
+	// ZombieTimeout zombie timeout,defaultvalue is 10000 milliseconds
+	ZombieTimeout = 10000
 	//QueueCap queue gap
 	QueueCap int = 10000000
 

--- a/tars/tarsprotocol.go
+++ b/tars/tarsprotocol.go
@@ -181,4 +181,3 @@ func (s *TarsProtocol) GetCloseMsg() []byte {
 func (s *TarsProtocol) DoClose(ctx context.Context) {
 	TLOG.Debug("DoClose!")
 }
-

--- a/tars/tools/Demo/Servant_imp.go
+++ b/tars/tools/Demo/Servant_imp.go
@@ -9,7 +9,7 @@ type _SERVANT_Imp struct {
 }
 
 // Init servant init
-func (imp *_SERVANT_Imp) Init() (error) {
+func (imp *_SERVANT_Imp) Init() error {
 	//initialize servant here:
 	//...
 	return nil

--- a/tars/tools/Demo/main.go
+++ b/tars/tools/Demo/main.go
@@ -24,7 +24,7 @@ func main() {
 	app := new(_APP_._SERVANT_)
 	// Register Servant
 	app.AddServantWithContext(imp, cfg.App+"."+cfg.Server+"._SERVANT_Obj")
-	
+
 	// Run application
 	tars.Run()
 }

--- a/tars/tools/Demo4Cmake/Servant_imp.go
+++ b/tars/tools/Demo4Cmake/Servant_imp.go
@@ -9,7 +9,7 @@ type _SERVANT_Imp struct {
 }
 
 // Init servant init
-func (imp *_SERVANT_Imp) Init() (error) {
+func (imp *_SERVANT_Imp) Init() error {
 	//initialize servant here:
 	//...
 	return nil

--- a/tars/tools/Demo4Cmake/main.go
+++ b/tars/tools/Demo4Cmake/main.go
@@ -24,7 +24,7 @@ func main() {
 	app := new(_APP_._SERVANT_)
 	// Register Servant
 	app.AddServantWithContext(imp, cfg.App+"."+cfg.Server+"._SERVANT_Obj")
-	
+
 	// Run application
 	tars.Run()
 }

--- a/tars/tools/Demo4GoMod/Servant_imp.go
+++ b/tars/tools/Demo4GoMod/Servant_imp.go
@@ -9,7 +9,7 @@ type _SERVANT_Imp struct {
 }
 
 // Init servant init
-func (imp *_SERVANT_Imp) Init() (error) {
+func (imp *_SERVANT_Imp) Init() error {
 	//initialize servant here:
 	//...
 	return nil

--- a/tars/tools/Demo4GoMod/main.go
+++ b/tars/tools/Demo4GoMod/main.go
@@ -24,7 +24,7 @@ func main() {
 	app := new(_APP_._SERVANT_)
 	// Register Servant
 	app.AddServantWithContext(imp, cfg.App+"."+cfg.Server+"._SERVANT_Obj")
-	
+
 	// Run application
 	tars.Run()
 }

--- a/tars/transport/udphandler.go
+++ b/tars/transport/udphandler.go
@@ -87,7 +87,6 @@ func (h *udpHandler) Handle() error {
 			atomic.AddInt32(&h.ts.numInvoke, -1)
 		}()
 	}
-	return nil
 }
 
 func (h *udpHandler) OnShutdown() {

--- a/tars/util/debug/debugtool_test.go
+++ b/tars/util/debug/debugtool_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func TestDumpStack(t *testing.T) {
-	DumpStack(true, "testdump")
+	DumpStack(true, "testdump", "testdump")
 }

--- a/tars/util/grace/grace_test.go
+++ b/tars/util/grace/grace_test.go
@@ -10,7 +10,7 @@ import (
 func TestListener(t *testing.T) {
 	proto, addr := "tcp", "localhost:3333"
 	_, err := CreateListener(proto, addr)
-	key := fmt.Sprintf("%s_%s_%s", ListenFdPrefix, proto, addr)
+	key := fmt.Sprintf("%s_%s_%s", InheritFdPrefix, proto, addr)
 	fmt.Println(err, key, os.Getenv(key))
 	cmd := exec.Command("lsof", "-p", fmt.Sprint(os.Getpid()))
 	cmd.Stdout = os.Stdout
@@ -19,7 +19,7 @@ func TestListener(t *testing.T) {
 	cmd.Wait()
 	addr = "localhost:3334"
 	_, err = CreateUDPConn(addr)
-	key = fmt.Sprintf("%s_%s_%s", ListenFdPrefix, "udp", addr)
+	key = fmt.Sprintf("%s_%s_%s", InheritFdPrefix, "udp", addr)
 	fmt.Println(err, key, os.Getenv(key))
 	cmd = exec.Command("lsof", "-p", fmt.Sprint(os.Getpid()))
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This PR fixes the following problems:

1. run `go fmt` against the code base
2. fix several problems identified by `go vet`, such as unreachable code, broken tests, missing struct field names.
3. bump openzipkin-contrib/zipkin-go-opentracing to v0.4.5, fix broken plugin
4. fix typo, `zombile` to `zombie` 