### PR TITLE
Improve performance of codec

### DIFF
--- a/tars/protocol/codec/codec.go
+++ b/tars/protocol/codec/codec.go
@@ -875,8 +875,12 @@ func NewReader(data []byte) *Reader {
 }
 
 // NewBuffer returns *Buffer
-func NewBuffer() *Buffer {
-	return &Buffer{buf: &bytes.Buffer{}}
+func NewBuffer(args ...*bytes.Buffer) *Buffer {
+	buf := &bytes.Buffer{}
+	if len(args) > 0 {
+		buf = args[0]
+	}
+	return &Buffer{buf: buf}
 }
 
 // FromInt8 NewReader(FromInt8(vec))


### PR DESCRIPTION
在单独使用codec场景下，在返回tars结构体时因为长度要放在前面，需要copy多一次内存，如果在写入buffer先把长度写入，就不需要多copy一次内存。
另外考虑兼容性，使用可选参数的方式。