### PR TITLE
correcting error output 'endoint' -> 'endpoint'

### DIFF
--- a/tars/endpointmanager.go
+++ b/tars/endpointmanager.go
@@ -128,7 +128,7 @@ func (g *globalManager) updateEndpoints() {
 		for _, e := range eps {
 			err := e.doFresh()
 			if err != nil {
-				TLOG.Errorf("update endoint error, %s.", e.objName)
+				TLOG.Errorf("update endpoint error, %s.", e.objName)
 			}
 
 		}


### PR DESCRIPTION
tars/endpointmanager.go 有一处Log异常输出有拼写错误，写成了 'endoint'